### PR TITLE
feat: add .gitattributes to skeleton

### DIFF
--- a/src/Maker/BundleFileMaker.php
+++ b/src/Maker/BundleFileMaker.php
@@ -65,5 +65,7 @@ class BundleFileMaker
                 'vendor-prefix' => Inflector::vendory($options->name),
             ], sprintf('translations/%s.fr.xlf', Inflector::className($options->name)));
         }
+
+        $this->fileCreator->create('.gitattributes');
     }
 }

--- a/templates/.gitattributes.template
+++ b/templates/.gitattributes.template
@@ -1,0 +1,5 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+.github export-ignore
+docs export-ignore
+tests export-ignore

--- a/tests/Expected/acme-bundle/.gitattributes.expected
+++ b/tests/Expected/acme-bundle/.gitattributes.expected
@@ -1,0 +1,5 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+.github export-ignore
+docs export-ignore
+tests export-ignore

--- a/tests/Maker/BundleFileMakerTest.php
+++ b/tests/Maker/BundleFileMakerTest.php
@@ -37,6 +37,7 @@ class BundleFileMakerTest extends MakerTestCase
         $this->assertGenFile('templates/hello.html.twig');
         $this->assertGenFile('translations/FooBundle.fr.xlf');
         $this->assertGenFile('README.md');
+        $this->assertGenFile('.gitattributes');
     }
 
     public function testThrowsExceptionWhenUnableToCreateReadmeFile(): void


### PR DESCRIPTION
In order to reduce the bundle size in vendors, the `.gitattributes` file can be added to exclude unneeded files