### PR TITLE
bump to nikic/php-parser 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=8.1",
         "composer-plugin-api": "^2.3",
-        "nikic/php-parser": "^4.17"
+        "nikic/php-parser": "^5.0"
     },
     "require-dev": {
         "composer/composer": "^2.6",

--- a/tests/Expected/acme-bundle/src/FooBundle.php.expected
+++ b/tests/Expected/acme-bundle/src/FooBundle.php.expected
@@ -11,7 +11,7 @@ use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
  */
 class FooBundle extends AbstractBundle
 {
-    public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder) : void
+    public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
         $container->import('../config/services.php');
     }

--- a/tests/Expected/acme-bundle/src/FooWithConfigBundle.php.expected
+++ b/tests/Expected/acme-bundle/src/FooWithConfigBundle.php.expected
@@ -12,12 +12,12 @@ use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
  */
 class FooWithConfigBundle extends AbstractBundle
 {
-    public function configure(DefinitionConfigurator $definition) : void
+    public function configure(DefinitionConfigurator $definition): void
     {
         $definition->import('../config/definition.php');
     }
     
-    public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder) : void
+    public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
         $container->import('../config/services.php');
     }


### PR DESCRIPTION
Generated code no longer has the space before the colon, tests fixed to reflect that.  Fixes #2